### PR TITLE
Fix boot sequence text alignment and welcome message

### DIFF
--- a/AnimationManager.cpp
+++ b/AnimationManager.cpp
@@ -500,7 +500,7 @@ void handleBootSequence() {
                 stateActionCompleted = true;
             }
             if (elapsed > 1000 && !typingStarted) {
-                typeTextOnDisplay(presRow, "INITIATE PWR", 100, true);
+                typeTextOnDisplay(presRow, " INITIATE PWR", 100, true);
                 typingStarted = true;
             }
             if (elapsed > BOOT_COLD_START_DURATION) {
@@ -644,28 +644,23 @@ void handleBootSequence() {
         case BOOT_ARRIVAL:
             if (!stateActionCompleted) {
                 playSound("/arrival_chime.mp3");
+                blankAllDisplays();
+                printToDisplay(destRow.year, "ARRI");
+                printToDisplay(destRow.time, "VAL");
+                printToDisplay(presRow.year, "OUTA");
+                printToDisplay(presRow.time, "TIME");
+
+                destRow.year.writeDisplay();
+                destRow.time.writeDisplay();
+                presRow.year.writeDisplay();
+                presRow.time.writeDisplay();
                 stateActionCompleted = true;
             }
-            if (audio.isRunning()) {
-                if (!stateActionCompleted) {
-                    blankAllDisplays();
-                    printToDisplay(destRow.year, "ARRI");
-                    printToDisplay(destRow.time, "VAL");
-                    printToDisplay(presRow.year, "OUTA");
-                    printToDisplay(presRow.time, "TIME");
-
-                    destRow.year.writeDisplay();
-                    destRow.time.writeDisplay();
-                    presRow.year.writeDisplay();
-                    presRow.time.writeDisplay();
-                    stateActionCompleted = true;
-                }
-                if (elapsed > 3000) {
-                    printToDisplay(lastRow.year, "WEL");
-                    printToDisplay(lastRow.time, "COME");
-                    lastRow.year.writeDisplay();
-                    lastRow.time.writeDisplay();
-                }
+            if (elapsed > 3000) {
+                printToDisplay(lastRow.year, "WEL");
+                printToDisplay(lastRow.time, "COME");
+                lastRow.year.writeDisplay();
+                lastRow.time.writeDisplay();
             }
             if (elapsed > BOOT_ARRIVAL_DURATION) {
                 bootState = BOOT_COOL_DOWN;


### PR DESCRIPTION
- Shifted the "INITIATE PWR" text one character to the right during the boot sequence as requested.
- Refactored the boot sequence logic to ensure the "WELCOME" message is reliably displayed at the end of the boot animation.